### PR TITLE
Modify prediction function to accept larger range of models, update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # MNIST Interactive Model Analyzer
 
 An interactive tool for experimenting with MNIST handwriting recognition models using a custom-built 28x28 drawing grid. This application allows users to draw digits and get real-time predictions from a trained MNIST model.
-Of note; currently all models will be fed numpy an array of shape (1, 784), with normalised greyscale values between [0, 1] inclusive, so will only work with basic models, more compatibility will be available soon.
 
 ## Features
 
@@ -11,6 +10,7 @@ Of note; currently all models will be fed numpy an array of shape (1, 784), with
 - Clear canvas functionality
 - Grid overlay for precise pixel manipulation
 - Support for custom MNIST-compatible models
+- Allows for custom conversion and output functions to allow for increased compatability with different model types.
 
 ## Installation
 
@@ -87,13 +87,15 @@ app = NumberCreatorWindow(root, model=model, blur=0.15)  # Adjust blur intensity
 ### NumberCreatorWindow
 
 ```python
-NumberCreatorWindow(root, model, blur=0.1)
+NumberCreatorWindow(root, model, blur=0.1, conversion_function, output_function)
 ```
 
 Parameters:
 - `root`: Tkinter root window
 - `model`: TensorFlow model for digit prediction
 - `blur`: Blur intensity for drawing (default: 0.1)
+- `conversion_function`: Function receiving a 28×28 NumPy array and returning data in the shape/format the model accepts
+- `output function`: Function receiving the model’s raw output (e.g. probability array) and returning a tuple of (prediction int, confidence float)
 
 ### Methods
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -4,7 +4,7 @@ import tkinter as tk
 from tkinter import ttk
 
 # To install the package:
-# pip install -i https://test.pypi.org/simple/ mnist-interactive
+# pip install -i https://test.pypi.org/simple/mnist-interactive
 
 # Load your pre-trained MNIST model
 model = tf.keras.models.load_model('sampleModel.keras')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mnist_interactive"
-version = "1.0.4"
+version = "1.0.5"
 authors = [
   { name="Luca Lowndes", email="Luca@Lowndes.net" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mnist_interactive',
-    version='1.0.4',
+    version='1.0.5',
     description='A library for experimenting with MNIST models using an interactive 28x28 grid.',
     author='Luca Lowndes',
     author_email='Luca@Lowndes.net',

--- a/src/mnist_interactive/numberCreatorWindow.py
+++ b/src/mnist_interactive/numberCreatorWindow.py
@@ -8,7 +8,13 @@ from . import utils as utils
 
 class NumberCreatorWindow:
 
-    def __init__(self, root, model, blur=0.1):
+    # root: Tkinter root window
+    # model: Trained model
+    # blur: Amount of blur to add to the drawing
+    # conversion_function: Function to convert the numpy array created by the Tkinter window to the format expected by the model
+    # output_function: Function to convert the output of the model to a human-readable format
+
+    def __init__(self, root, model, blur=0.1, conversion_function=None, ouptut_function=None):
         self.root = root
         self.root.title("MNIST Drawing App")
 
@@ -87,10 +93,7 @@ class NumberCreatorWindow:
                         self.grid_data, self.canvas,
                         y, x, bx1, bx2, by1, by2,
                         self.blur
-                    )
-                
-
-                
+                    )            
     
     def start_removing(self, event):
         self.removing = True
@@ -121,7 +124,7 @@ class NumberCreatorWindow:
 
 
     def predict(self):
-        prediction, confidence = utils.predict(self.model, self.grid_data)
+        prediction, confidence = utils.predict(self.model, self.grid_data, self.conversion_function, self.ouptut_function)
         self.prediction_label.config(text=f"Prediction: {prediction} Confidence: {confidence:.2f}")
         self.root.update()
 

--- a/src/mnist_interactive/utils.py
+++ b/src/mnist_interactive/utils.py
@@ -1,14 +1,26 @@
 import numpy as np
 import tensorflow as tf
 
-def predict(model, data):
+def predict(model, data, conversion_function, output_function):
     if model is None:
         print("Model is not loaded")
         return 0, 0
-    x = np.array(data).reshape(1, 784)
+    
+    x = np.array()
+
+    # If no conversion function is provided, assume the data is to be reshaped to (1, 784)
+    if conversion_function is None:
+        x = np.array(data).reshape(1, 784)
+    else:
+        x = conversion_function(data)
 
     prediction = model.predict(x)
-    return np.argmax(prediction), prediction[0][np.argmax(prediction)]
+
+    # If no output function is provided, revert to default where the output is the index of the highest value
+    if conversion_function is None:
+        return np.argmax(prediction), prediction[0][np.argmax(prediction)]
+    
+    return output_function(prediction)
 
 def drawGridLines(canvas):
     for i in range(29):


### PR DESCRIPTION
Increased compatibility with different models through allowing different types of input and output functions to and from the model, whilst maintaining the simplicity of the existing infrastructure, allowing for 'plug and play' when using simple models which take (1, 784) as input and provide outputs in this form: 
- `np.argmax(prediction)`,  prediction (int)
- `prediction[0][np.argmax(prediction)]`, confidence (float)

whilst ensuring compatibility with more complex functionality for models which require it.
Additionally, README.md was updated inline with these changes.